### PR TITLE
Implement --hotreload switch in CLI

### DIFF
--- a/jdaviz/cli.py
+++ b/jdaviz/cli.py
@@ -43,7 +43,11 @@ CONFIGS_DIR = os.path.join(os.path.dirname(__file__), 'configs')
               show_default=True,
               type=click.Choice(['debug', 'info', 'warning', 'error']),
               help="Verbosity of the application")
-def main(filename, layout='default', browser='default', theme='light', verbosity='info'):
+@click.option('--hotreload/--no-hotreload',
+              default=False,
+              help="Whether to enable hot-reloading of the UI (for development)")
+def main(filename, layout='default', browser='default', theme='light', verbosity='info', 
+         hotreload=False):
     """
     Start a Jdaviz application instance with data loaded from FILENAME.
 
@@ -59,6 +63,8 @@ def main(filename, layout='default', browser='default', theme='light', verbosity
         Theme to use for Voila app or Jupyter Lab.
     verbosity : {'debug', 'info', 'warning', 'error'}
         Verbosity of the application.
+    hotreload: bool
+        Whether to enable hot-reloading of the UI (for development)
     """
     # Tornado Webserver py3.8 compatibility hotfix for windows
     if sys.platform == 'win32':
@@ -79,6 +85,9 @@ def main(filename, layout='default', browser='default', theme='light', verbosity
     os.environ['JDAVIZ_START_DIR'] = start_dir
 
     nbdir = tempfile.mkdtemp()
+
+    if hotreload:
+        notebook_template = notebook_template.replace("# PREFIX", "from jdaviz import enable_hot_reloading; enable_hot_reloading()")  # noqa: E501
 
     with open(os.path.join(nbdir, 'notebook.ipynb'), 'w') as nbf:
         nbf.write(notebook_template.replace('DATA_FILENAME', filepath).replace('JDAVIZ_VERBOSITY', verbosity).strip())  # noqa: E501

--- a/jdaviz/configs/cubeviz/cubeviz.ipynb
+++ b/jdaviz/configs/cubeviz/cubeviz.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# PREFIX\n",
     "from jdaviz import Cubeviz\n",
     "\n",
     "cubeviz = Cubeviz(verbosity='JDAVIZ_VERBOSITY')\n",

--- a/jdaviz/configs/imviz/imviz.ipynb
+++ b/jdaviz/configs/imviz/imviz.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# PREFIX\n",
     "from jdaviz import Imviz\n",
     "\n",
     "imviz = Imviz(verbosity='JDAVIZ_VERBOSITY')\n",

--- a/jdaviz/configs/mosviz/mosviz.ipynb
+++ b/jdaviz/configs/mosviz/mosviz.ipynb
@@ -8,6 +8,7 @@
    },
    "outputs": [],
    "source": [
+    "# PREFIX\n",
     "import pathlib\n",
     "import tempfile\n",
     "import uuid\n",

--- a/jdaviz/configs/specviz/specviz.ipynb
+++ b/jdaviz/configs/specviz/specviz.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# PREFIX\n"
     "from jdaviz import Specviz\n",
     "\n",
     "specviz = Specviz(verbosity='JDAVIZ_VERBOSITY')\n",


### PR DESCRIPTION
* adds a `--hotreload`/`--no-hotreload` boolean switch (defaults to False) to the jdaviz CLI
* if `--hotreload` is passed, `jdaviz.enable_hot_reloading()` is injected as the first line in the notebooks passed to voila (by replacing a new `# PREFIX` line at the top of each template notebook).