### PR TITLE
Fix reordering layers in data menu when WCS linked in Imviz

### DIFF
--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -324,19 +324,29 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
 
     @observe('layer_selected', 'layer_items')
     def _layers_changed(self, event={}):
-        if event.get('name') == 'layer_items' and len(event['new']) == len(self.data_labels_loaded):
+
+        # Have to count subsets + data, but not the invisible WCS layers in Imviz
+        data_menu_len = len(self.existing_subset_labels) + len(self.data_labels_loaded)
+
+        if (event.get('name') == 'layer_items' and len(event['new']) == data_menu_len
+                and isinstance(event.get('owner'), DataMenu)):
             # Setting layer.zorder causes a change to layer_items, which causes this function to be
             # immediately called again. Use this flag to prevent that.
             if self.prevent_layer_items_recursion:
                 return
             self.prevent_layer_items_recursion = True
             label_order = [li['label'] for li in event["new"]]
+            not_in_order = [layer.layer.label for layer in self._viewer.layers if layer.layer.label
+                            not in label_order]
 
             for layer in self._viewer.layers:
-                if is_not_wcs_only(layer):
-                    new_zorder = len(self._viewer.layers) - label_order.index(layer.layer.label)
-                    if new_zorder != layer.zorder:
-                        layer.zorder = new_zorder
+                if layer.layer.label in label_order:
+                    new_zorder = len(label_order) - label_order.index(layer.layer.label)
+                else:
+                    new_zorder = len(not_in_order) + len(label_order) - not_in_order.index(layer.layer.label)  # noqa
+
+                if new_zorder != layer.zorder:
+                    layer.zorder = new_zorder
 
             self.prevent_layer_items_recursion = False
         if not hasattr(self, 'layer') or not self.layer.multiselect:  # pragma: no cover

--- a/jdaviz/configs/default/plugins/data_menu/data_menu.py
+++ b/jdaviz/configs/default/plugins/data_menu/data_menu.py
@@ -324,7 +324,7 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
 
     @observe('layer_selected', 'layer_items')
     def _layers_changed(self, event={}):
-        if event.get('name') == 'layer_items' and len(event['new']) == len(self._viewer.layers):
+        if event.get('name') == 'layer_items' and len(event['new']) == len(self.data_labels_loaded):
             # Setting layer.zorder causes a change to layer_items, which causes this function to be
             # immediately called again. Use this flag to prevent that.
             if self.prevent_layer_items_recursion:
@@ -333,9 +333,10 @@ class DataMenu(TemplateMixin, LayerSelectMixin, DatasetSelectMixin):
             label_order = [li['label'] for li in event["new"]]
 
             for layer in self._viewer.layers:
-                new_zorder = len(self._viewer.layers) - label_order.index(layer.layer.label)
-                if new_zorder != layer.zorder:
-                    layer.zorder = new_zorder
+                if is_not_wcs_only(layer):
+                    new_zorder = len(self._viewer.layers) - label_order.index(layer.layer.label)
+                    if new_zorder != layer.zorder:
+                        layer.zorder = new_zorder
 
             self.prevent_layer_items_recursion = False
         if not hasattr(self, 'layer') or not self.layer.multiselect:  # pragma: no cover


### PR DESCRIPTION
This allows dragging and dropping to change the layer order when WCS linked, in which case there are one or more invisible layers in the viewer that are not shown in the data menu. 

@mariobuikhuizen this for some reason leads to a layer order change in the data menu when updating a layer's color, which I don't fully understand, considering the visible layers are still in the same relative order. The z_orders change from 1, 2, 3 to 2, 3, 4, but the lowest layer (which is the one I changed colormap for) ends up in the middle in the data menu.